### PR TITLE
Allow '+' in email address when splitting email from IP address

### DIFF
--- a/src/Validator.php
+++ b/src/Validator.php
@@ -146,7 +146,8 @@ class Validator
     {
         $parsed = [];
 
-        $parameters = explode('+', $parameters['query']);
+        // Make sure to handle an email with a '+' in it, always taking the last part
+        $parameters = preg_split('/\+(?=[^+]*$)/', $parameters['query']);
 
         if (isset($parameters[1])) {
             $parsed['email'] = $parameters[0];


### PR DESCRIPTION
Previously, if an email address had a '+' in it, it would parse incorrectly.

joe+user@example.com+127.0.0.1 would parse as (joe, user@example.com+127.0.0.1). It now correctly parses as (joe+user@example.com, 127.0.0.1).

Continues to work correctly with no '+' or only a singe '+'.